### PR TITLE
Potential fix for code scanning alert no. 43: Useless conditional

### DIFF
--- a/convex/appointmentTypes.ts
+++ b/convex/appointmentTypes.ts
@@ -313,12 +313,7 @@ export const importAppointmentTypesFromCsv = mutation({
         }
       }
 
-      if (!practitionerName || !locationName) {
-        console.warn(
-          `Could not parse practitioner and location from header: ${header}`,
-        );
-        continue;
-      }
+
 
       // Get or create location
       let locationId = locationNameToId.get(locationName);

--- a/convex/appointmentTypes.ts
+++ b/convex/appointmentTypes.ts
@@ -313,8 +313,6 @@ export const importAppointmentTypesFromCsv = mutation({
         }
       }
 
-
-
       // Get or create location
       let locationId = locationNameToId.get(locationName);
       if (!locationId) {


### PR DESCRIPTION
Potential fix for [https://github.com/johannesbremer/praxisplaner/security/code-scanning/43](https://github.com/johannesbremer/praxisplaner/security/code-scanning/43)

To fix the problem, we should remove the redundant conditional on line 316 and its associated block (lines 316–321). This will not change the program's behavior, as the only way to reach this point is if both `practitionerName` and `locationName` are already truthy. The fix is to simply delete these lines from the file `convex/appointmentTypes.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
