### PR TITLE
Fix default practice initialization after deleted practice cleanup

### DIFF
--- a/convex/practices.ts
+++ b/convex/practices.ts
@@ -107,13 +107,18 @@ export const initializeDefaultPractice = mutation({
   args: {},
   handler: async (ctx) => {
     const userId = await ensureAuthenticatedUserId(ctx);
-    const existingMembership = await ctx.db
+    const existingMemberships = await ctx.db
       .query("practiceMembers")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
-      .first();
+      .collect();
 
-    if (existingMembership) {
-      return existingMembership.practiceId;
+    for (const membership of existingMemberships) {
+      const practice = await ctx.db.get("practices", membership.practiceId);
+      if (practice) {
+        return membership.practiceId;
+      }
+
+      await ctx.db.delete("practiceMembers", membership._id);
     }
 
     const existingPractices = await ctx.db.query("practices").collect();

--- a/convex/tests/practices.test.ts
+++ b/convex/tests/practices.test.ts
@@ -1,0 +1,64 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+
+import { api } from "../_generated/api";
+import schema from "../schema";
+import { modules } from "./test.setup";
+
+function createAuthedTestContext() {
+  return convexTest(schema, modules).withIdentity({
+    email: "practices@example.com",
+    subject: "workos_practices",
+  });
+}
+
+describe("Practices", () => {
+  test("initializeDefaultPractice recreates a practice when memberships point to deleted practices", async () => {
+    const t = createAuthedTestContext();
+
+    const originalPracticeId = await t.mutation(api.practices.createPractice, {
+      name: "Deleted Practice",
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.delete("practices", originalPracticeId);
+    });
+
+    const recreatedPracticeId = await t.mutation(
+      api.practices.initializeDefaultPractice,
+      {},
+    );
+
+    expect(recreatedPracticeId).not.toEqual(originalPracticeId);
+
+    const state = await t.run(async (ctx) => {
+      const recreatedPractice = await ctx.db.get(
+        "practices",
+        recreatedPracticeId,
+      );
+      const memberships = await ctx.db
+        .query("practiceMembers")
+        .withIndex("by_practiceId", (q) =>
+          q.eq("practiceId", recreatedPracticeId),
+        )
+        .collect();
+      const danglingMemberships = await ctx.db
+        .query("practiceMembers")
+        .withIndex("by_practiceId", (q) =>
+          q.eq("practiceId", originalPracticeId),
+        )
+        .collect();
+
+      return {
+        danglingMemberships,
+        memberships,
+        recreatedPractice,
+      };
+    });
+
+    expect(state.recreatedPractice?.name).toEqual("Standardpraxis");
+    expect(state.recreatedPractice?.currentActiveRuleSetId).toBeDefined();
+    expect(state.memberships).toHaveLength(1);
+    expect(state.danglingMemberships).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- update `initializeDefaultPractice` to skip and remove stale `practiceMembers` rows that reference deleted practices
- allow initialization to continue by returning the first valid practice membership or creating a new default practice when none remain
- add a regression test covering deleted practices with dangling memberships

## Testing
- `npm exec -- pnpm vitest run convex/tests/practices.test.ts`